### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/functionalTest/00newsFunctionalTest.js
+++ b/functionalTest/00newsFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('news functional test', function () {
 

--- a/functionalTest/01festivalsFunctionalTest.js
+++ b/functionalTest/01festivalsFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('festivals functional test', function () {
 

--- a/functionalTest/02festivalsNewsFunctionalTest.js
+++ b/functionalTest/02festivalsNewsFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('news functional test', function () {
 

--- a/functionalTest/03festivalsPlacesFunctionalTest.js
+++ b/functionalTest/03festivalsPlacesFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('festivals places functional test', function () {
 

--- a/functionalTest/04festivalsCategoriesFunctionalTest.js
+++ b/functionalTest/04festivalsCategoriesFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('festivals categories functional test', function () {
 

--- a/functionalTest/05festivalsEventsFunctionalTest.js
+++ b/functionalTest/05festivalsEventsFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('festivals events functional test', function () {
 

--- a/functionalTest/99CleanupFunctionalTest.js
+++ b/functionalTest/99CleanupFunctionalTest.js
@@ -2,7 +2,7 @@ var funcTest = require('./initFunctionalTests');
 var config = require('config');
 var hippie = require('hippie');
 var moment = require('moment');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('festivals delete functional test', function () {
 

--- a/lib/domain/builder/categoryBuilders.js
+++ b/lib/domain/builder/categoryBuilders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var moment = require('moment');
 
 var validator = require('../../validator').validator;

--- a/lib/domain/builder/eventBuilders.js
+++ b/lib/domain/builder/eventBuilders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var moment = require('moment');
 
 var validator = require('../../validator').validator;

--- a/lib/domain/builder/festivalBuilders.js
+++ b/lib/domain/builder/festivalBuilders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var assert = require('assert-plus');
 var moment = require('moment');
 

--- a/lib/domain/builder/newsBuilders.js
+++ b/lib/domain/builder/newsBuilders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var moment = require('moment');
 
 var validator = require('../../validator').validator;

--- a/lib/domain/builder/placeBuilders.js
+++ b/lib/domain/builder/placeBuilders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var moment = require('moment');
 
 var validator = require('../../validator').validator;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "moment": "2.14.1",
     "my-restify-api": "0.6.3",
     "newrelic": "1.29.0",
-    "node-uuid": "1.4.7",
+    "uuid": "^3.0.0",
     "winston": "2.2.0",
     "winston-loggly": "1.3.1"
   },

--- a/test/provider/providerTest.js
+++ b/test/provider/providerTest.js
@@ -1,5 +1,5 @@
 var config = require('config');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var moment = require('moment');
 var chai = require('chai');
 var should = chai.should();


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.